### PR TITLE
Fix depreciation warnings on 0.4, windows compatible

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,0 +1,3 @@
+julia 0.4
+JSON
+Mustache

--- a/src/Judo.jl
+++ b/src/Judo.jl
@@ -12,11 +12,11 @@ include("collate.jl")
 # An iterator for the parse function: parsit(source) will iterate over the
 # expressiosn in a string.
 type ParseIt
-    value::String
+    value::AbstractString
 end
 
 
-function parseit(value::String)
+function parseit(value::AbstractString)
     ParseIt(value)
 end
 
@@ -53,7 +53,7 @@ end
 # Returns:
 #   A string containing the output from pandoc.
 #
-function pandoc(input::String, infmt::Symbol, outfmt::Symbol, args::String...)
+function pandoc(input::AbstractString, infmt::Symbol, outfmt::Symbol, args::AbstractString...)
     cmd = ByteString["pandoc",
                      "--from=$(string(infmt))",
                      "--to=$(string(outfmt))"]
@@ -68,7 +68,7 @@ end
 
 
 # Convert a string to a structure interpretable by pandoc json parser.
-function string_to_pandoc_json(s::String)
+function string_to_pandoc_json(s::AbstractString)
     out = {}
     for mat in eachmatch(r"\S+", s)
         if !isempty(out)
@@ -90,7 +90,7 @@ type WeaveDoc <: Display
     display_blocks::Array
 
     # Document name (used for naming any external files generated)
-    name::String
+    name::AbstractString
 
     # Output formal
     outfmt::Symbol
@@ -103,10 +103,10 @@ type WeaveDoc <: Display
     stdout_write
 
     # Output directory
-    outdir::String
+    outdir::AbstractString
 
-    function WeaveDoc(name::String, outfmt::Symbol, stdout_read, stdout_write,
-                      outdir::String)
+    function WeaveDoc(name::AbstractString, outfmt::Symbol, stdout_read, stdout_write,
+                      outdir::AbstractString)
         new({}, {}, name, outfmt, 1, stdout_read, stdout_write, outdir)
     end
 end
@@ -236,10 +236,10 @@ end
 
 
 # This is maybe an abuse. TODO: This is going to be a problem.
-writemime(io, m::MIME"text/vnd.graphviz", data::String) = write(io, data)
-writemime(io, m::MIME"image/vnd.graphviz", data::String) = write(io, data)
-writemime(io, m::MIME"image/svg+xml", data::String) = write(io, data)
-writemime(io, m::MIME"text/latex", data::String) = write(io, data)
+writemime(io, m::MIME"text/vnd.graphviz", data::AbstractString) = write(io, data)
+writemime(io, m::MIME"image/vnd.graphviz", data::AbstractString) = write(io, data)
+writemime(io, m::MIME"image/svg+xml", data::AbstractString) = write(io, data)
+writemime(io, m::MIME"text/latex", data::AbstractString) = write(io, data)
 
 
 # Turn YAML frontmatter parsed by pandoc into simplified julia structure.
@@ -251,7 +251,7 @@ writemime(io, m::MIME"text/latex", data::String) = write(io, data)
 #   A (String => String) dictionary with key value pairs.
 #
 function flatten_pandoc_metadata(pandoc_metadata::Dict)
-    metadata = Dict{String, String}()
+    metadata = Dict{AbstractString, AbstractString}()
     for (key, val) in pandoc_metadata["unMeta"]
         if val["t"] == "MetaInlines"
             metadata[key] = flatten_pandoc_metainlines(val["c"])
@@ -316,7 +316,7 @@ end
 #
 function weave(input::IO, output::IO;
                outfmt=:html5, name="judo", template=nothing,
-               toc::Bool=false, outdir::String=".", dryrun::Bool=false,
+               toc::Bool=false, outdir::AbstractString=".", dryrun::Bool=false,
                keyvals::Dict=Dict(),
                pandocargs=nothing)
     input_text = readall(input)
@@ -369,7 +369,7 @@ function weave(input::IO, output::IO;
     pandoc_metadata["today"] =
         {"t" => "MetaInlines",
          "c" => {{"t" => "Str",
-                  "c" => strip(readall(`date`))}}}
+                  "c" => string(Date(now()))}}}
 
     JSON.print(buf, {{"unMeta" => pandoc_metadata}, doc.blocks})
 

--- a/src/collate.jl
+++ b/src/collate.jl
@@ -10,7 +10,7 @@ const pkgurl_pat = r"github.com/(.*)\.git$"
 
 
 # Generate documentation from the given package.
-function collate(package::String; template::String="default")
+function collate(package::AbstractString; template::AbstractString="default")
     declarations = harvest(package)
 
     pkgver = ""
@@ -50,8 +50,8 @@ end
 
 # Generate documentation from multiple files.
 function collate(filenames::Vector;
-                 template::String="default",
-                 outdir::String=".",
+                 template::AbstractString="default",
+                 outdir::AbstractString=".",
                  declarations::Dict=Dict(),
                  pkgname=nothing,
                  pkgver=nothing,
@@ -87,7 +87,7 @@ function collate(filenames::Vector;
             toc[part] = {}
         end
 
-        push!(toc[part], (parseint(get(metadata, "order", "0")), name, title, sections))
+        push!(toc[part], (parse(Int,get(metadata, "order", "0")), name, title, sections))
     end
     for part_content in values(toc)
         sort!(part_content)
@@ -125,8 +125,10 @@ function collate(filenames::Vector;
     end
 
     # copy template files
-    run(`cp -r $(joinpath(template, "js")) $(outdir)`)
-    run(`cp -r $(joinpath(template, "css")) $(outdir)`)
+    #run(`cp -r $(joinpath(template, "js")) $(outdir)`)
+    cp(joinpath(template, "js"), joinpath(outdir, "js"), remove_destination=true)
+    #run(`cp -r $(joinpath(template, "css")) $(outdir)`)
+    cp(joinpath(template, "css"), joinpath(outdir, "css"), remove_destination=true)
 end
 
 
@@ -135,7 +137,7 @@ const fileext_pat = r"^(.+)\.([^\.]+)$"
 
 
 # Choose a documents name from its file name.
-function choose_document_name(filename::String)
+function choose_document_name(filename::AbstractString)
     filename = basename(filename)
     mat = match(fileext_pat, filename)
     name = filename
@@ -159,7 +161,7 @@ end
 
 
 # Generate a table of contents for the given document.
-function table_of_contents(toc, selected_title::String)
+function table_of_contents(toc, selected_title::AbstractString)
     parts = collect(keys(toc))
     part_order = [minimum([order for (order, name, title, sections) in toc[part]])
                   for part in parts]
@@ -233,7 +235,7 @@ end
 
 
 # Turn a section name into an html id.
-function section_id(section::String)
+function section_id(section::AbstractString)
     # Keep only unicode letters, _ and -
     cleaned = replace(section, r"[^\p{L}_\-\s]", "")
     lowercase(replace(cleaned, r"\s+", "-"))

--- a/src/harvest.jl
+++ b/src/harvest.jl
@@ -6,9 +6,9 @@ using DataStructures
 
 # Metadata parsed from a declarations's preceeding comment.
 type DeclarationComment
-    decltype::String
-    description::String
-    args::Union(OrderedDict, Nothing)
+    decltype::AbstractString
+    description::AbstractString
+    args::Union{OrderedDict, Void}
     sections::Dict
 
     function DeclarationComment(decltype, description)
@@ -48,7 +48,7 @@ const comment_strip_pat = r"\h*\#+"
 #   A three-tuple of the form (decltype, name, comment), where
 #   decltype is one of "function", "immutable", "type".
 #
-function extract_declaration_comments(input::String)
+function extract_declaration_comments(input::AbstractString)
     mats = {}
     comment_strip(txt) = replace(txt, comment_strip_pat, "")
 
@@ -71,7 +71,7 @@ end
 # Returns:
 #   A dictionary mapping declared identifiers to DeclarationComment objects.
 #
-function harvest(package::String)
+function harvest(package::AbstractString)
     srcdir = joinpath(Pkg.dir(package), "src")
     filenames = {}
     for filename in walkdir(srcdir)
@@ -107,7 +107,7 @@ end
 
 # Return a substring of input that is of equal or greater indentation than the
 # line starting at i.
-function get_indented_block(input::String, i::Integer=1)
+function get_indented_block(input::AbstractString, i::Integer=1)
     output = IOBuffer()
     n = length(input)
     block_indent = 0
@@ -163,7 +163,7 @@ const func_field_pat = r"^\h*(Args|Returns|Modifies|Throws)\s*:\h*\r?\n"im
 # Returns:
 #   A DeclarationComment object.
 #
-function parse_comment(decltype, input::String)
+function parse_comment(decltype, input::AbstractString)
     mat = match(func_field_pat, input)
     if mat == nothing
         return DeclarationComment(decltype, strip(input))
@@ -201,7 +201,7 @@ const arg_desc_pat = r"^(\h*)([\w_][\w\d_\!]*(?:\.\.\.)?)\h*:\h*(.*)\r?"m
 # Returns:
 #   A dictionary mapping arugment names to their descriptions.
 #
-function parse_comment_args(input::String)
+function parse_comment_args(input::AbstractString)
     args = OrderedDict()
     mat = match(arg_desc_pat, input)
     while mat != nothing
@@ -266,7 +266,7 @@ end
 
 
 # Insert function declaration comments into a markdown document.
-function expand_declaration_docs(input::String, declaration_markdown::Dict)
+function expand_declaration_docs(input::AbstractString, declaration_markdown::Dict)
     Mustache.render(input, declaration_markdown)
 end
 

--- a/src/semanticize.jl
+++ b/src/semanticize.jl
@@ -1,7 +1,7 @@
 
 # Return a substring of input that is of equal or greater indentation than the
 # line starting at i.
-function get_indented_block(input::String, i::Integer=1)
+function get_indented_block(input::AbstractString, i::Integer=1)
     output = IOBuffer()
     n = length(input)
     block_indent = 0
@@ -56,7 +56,7 @@ const func_field_pat = r"^\h*(Args|Returns|Modifies|Throws)\s*:\h*\r?\n"im
 # Returns:
 #   A four-tuple of the form (description, args, returns, modifies, throws)
 #
-function parse_function_comment(input::String)
+function parse_function_comment(input::AbstractString)
     mat = match(func_field_pat, input)
     if mat == nothing
         return (strip(input), nothing, nothing, nothing, nothing, nothing)
@@ -104,7 +104,7 @@ const arg_desc_pat = r"^(\h*)([\w_][\w\d_\!]*)\h*:\h*(.*)\r?"m
 # Returns:
 #   A dictionary mapping arugment names to their descriptions.
 #
-function parse_function_comment_args(input::String)
+function parse_function_comment_args(input::AbstractString)
     args = Dict()
     mat = match(arg_desc_pat, input)
     while mat != nothing

--- a/src/walkdir.jl
+++ b/src/walkdir.jl
@@ -8,10 +8,10 @@
 # Returns:
 #   A vector of paths relative to root.
 #
-function walkdir(root::String)
+function walkdir(root::AbstractString)
     root = abspath(root)
-    contents = String[]
-    stack = String[]
+    contents = AbstractString[]
+    stack = AbstractString[]
     push!(stack, root)
     while !isempty(stack)
         path = pop!(stack)


### PR DESCRIPTION
Fix many depreciation warnings and also switch from using unix shell
commands to their julia versions.  
